### PR TITLE
Expose booking identifiers from Bokun API fetch

### DIFF
--- a/includes/bokun_settings.class.php
+++ b/includes/bokun_settings.class.php
@@ -39,8 +39,14 @@ if( !class_exists ( 'BOKUN_Settings' ) ) {
             if (is_string($bookings)) {
                 wp_send_json_success(array('msg' => esc_html($bookings),'status' => false));
             } else {
-                bokun_save_bookings_as_posts($bookings);
-                wp_send_json_success(array('msg' => 'Bookings have been successfully imported as custom posts.', 'status' => true));
+                $found_identifiers = isset($bookings['found_identifiers']) ? $bookings['found_identifiers'] : array();
+                $bookings_list = isset($bookings['bookings']) ? $bookings['bookings'] : array();
+                bokun_save_bookings_as_posts($bookings_list);
+                wp_send_json_success(array(
+                    'msg' => 'Bookings have been successfully imported as custom posts.',
+                    'status' => true,
+                    'foundBookings' => $found_identifiers,
+                ));
             }
 
             wp_die(); // Always end AJAX functions with wp_die()


### PR DESCRIPTION
## Summary
- stop writing booking discovery details to the WordPress debug log during Bokun API imports
- collect human-readable "found booking" messages for each identifier returned by the API
- surface the collected messages through the AJAX handler and REST endpoint responses

## Testing
- php -l includes/bokun-bookings-manager.php
- php -l includes/bokun_settings.class.php

------
https://chatgpt.com/codex/tasks/task_e_68d45db4e8808320bce20f2a18643f1d