### PR TITLE
Expose booking identifiers from Bokun API fetch

### DIFF
--- a/bokun-bookings-management.php
+++ b/bokun-bookings-management.php
@@ -348,9 +348,33 @@ class BokunBookingManagement {
 		global $rb,$bokun_settings,$bokun_booking,$bokun_timing;
 		if( isset($_REQUEST['page']) && $_REQUEST['page'] != '' ){
             switch ( $_REQUEST['page'] ) {
-				case $this->bokun_settings:
-					$bokun_settings->bokun_display_settings();
-					break;
+                        case $this->bokun_settings:
+                                if (!isset($bokun_settings) || !is_object($bokun_settings)) {
+                                        if (!class_exists('BOKUN_Settings')) {
+                                                $settings_file = BOKUN_INCLUDES_DIR . 'bokun_settings.class.php';
+                                                if (file_exists($settings_file)) {
+                                                        include_once $settings_file;
+                                                }
+                                        }
+
+                                        if (class_exists('BOKUN_Settings')) {
+                                                $bokun_settings = new BOKUN_Settings();
+                                        }
+
+                                        if (!isset($bokun_settings) || !is_object($bokun_settings)) {
+                                                printf(
+                                                        '<div class="notice notice-error"><p>%s</p></div>',
+                                                        esc_html__(
+                                                                'Unable to initialize Bokun settings. Please reactivate the plugin.',
+                                                                BOKUN_txt_domain
+                                                        )
+                                                );
+                                                break;
+                                        }
+                                }
+
+                                $bokun_settings->bokun_display_settings();
+                                break;
 			}
 		}
 	}

--- a/includes/bokun_settings.class.php
+++ b/includes/bokun_settings.class.php
@@ -39,8 +39,14 @@ if( !class_exists ( 'BOKUN_Settings' ) ) {
             if (is_string($bookings)) {
                 wp_send_json_success(array('msg' => esc_html($bookings),'status' => false));
             } else {
-                bokun_save_bookings_as_posts($bookings);
-                wp_send_json_success(array('msg' => 'Bookings have been successfully imported as custom posts.', 'status' => true));
+                $found_identifiers = isset($bookings['found_identifiers']) ? $bookings['found_identifiers'] : array();
+                $bookings_list = isset($bookings['bookings']) ? $bookings['bookings'] : array();
+                bokun_save_bookings_as_posts($bookings_list);
+                wp_send_json_success(array(
+                    'msg' => 'Bookings have been successfully imported as custom posts.',
+                    'status' => true,
+                    'foundBookings' => $found_identifiers,
+                ));
             }
 
             wp_die(); // Always end AJAX functions with wp_die()


### PR DESCRIPTION
## Summary
- guard the settings submenu route so it re-initializes the Bokun settings singleton when it is unexpectedly missing
- surface an admin error notice if the settings class cannot be loaded even after re-initialization

## Testing
- php -l bokun-bookings-management.php
- php -l includes/bokun_settings.class.php

------
https://chatgpt.com/codex/tasks/task_e_68d45db4e8808320bce20f2a18643f1d