### PR TITLE
Add booking dashboard shortcode with copy helpers and filters

### DIFF
--- a/assets/css/bokun_dashboard.css
+++ b/assets/css/bokun_dashboard.css
@@ -1,0 +1,245 @@
+.bokun-dashboard {
+  background-color: #fff;
+  border: 1px solid #dcdcde;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+  font-family: inherit;
+  color: #1d2327;
+}
+
+.bokun-dashboard-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  margin-bottom: 1.5rem;
+}
+
+.bokun-dashboard-search {
+  flex: 1 1 260px;
+  min-width: 220px;
+}
+
+.bokun-dashboard-search-input {
+  position: relative;
+}
+
+.bokun-dashboard-search-input input[type="search"] {
+  width: 100%;
+  padding: 0.625rem 2.5rem 0.625rem 0.75rem;
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.bokun-dashboard-search-input input[type="search"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 1px #2271b1;
+  border-color: #2271b1;
+}
+
+.bokun-dashboard-clear-search {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  color: #6c7781;
+  font-size: 1.125rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  display: none;
+}
+
+.bokun-dashboard-clear-search.is-visible {
+  display: block;
+}
+
+.bokun-dashboard-filters {
+  position: relative;
+}
+
+.bokun-dashboard-filter-toggle {
+  background-color: #2271b1;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background-color 0.2s ease;
+}
+
+.bokun-dashboard-filter-toggle:hover,
+.bokun-dashboard-filter-toggle:focus {
+  background-color: #1a5d92;
+  outline: none;
+}
+
+.bokun-dashboard-filter-dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  background: #fff;
+  border: 1px solid #dcdcde;
+  border-radius: 6px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+  padding: 0.75rem;
+  min-width: 240px;
+  z-index: 1000;
+  display: none;
+}
+
+.bokun-dashboard-filters.is-open .bokun-dashboard-filter-dropdown {
+  display: block;
+}
+
+.bokun-dashboard-filter-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.bokun-dashboard-filter-actions button {
+  flex: 1;
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+  background-color: #f0f0f1;
+  cursor: pointer;
+  padding: 0.4rem 0.5rem;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.bokun-dashboard-filter-actions button:hover,
+.bokun-dashboard-filter-actions button:focus {
+  background-color: #e2e2e3;
+  border-color: #8c8f94;
+  outline: none;
+}
+
+.bokun-dashboard-filter-options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.bokun-dashboard-filter-options li {
+  margin-bottom: 0.5rem;
+}
+
+.bokun-dashboard-filter-options li:last-child {
+  margin-bottom: 0;
+}
+
+.bokun-dashboard-filter-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.bokun-dashboard-table-wrapper {
+  overflow-x: auto;
+}
+
+.bokun-dashboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.bokun-dashboard-table th,
+.bokun-dashboard-table td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid #e2e4e7;
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.bokun-dashboard-table th {
+  background-color: #f6f7f7;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+}
+
+.bokun-dashboard-table a {
+  color: #2271b1;
+  text-decoration: none;
+}
+
+.bokun-dashboard-table a:hover,
+.bokun-dashboard-table a:focus {
+  text-decoration: underline;
+}
+
+.bokun-dashboard-copy-button {
+  margin-left: 0.5rem;
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+  background-color: #f0f0f1;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.bokun-dashboard-copy-button:hover,
+.bokun-dashboard-copy-button:focus {
+  background-color: #2271b1;
+  color: #fff;
+  border-color: #1a5d92;
+  outline: none;
+}
+
+.bokun-dashboard-copy-button.has-feedback {
+  background-color: #2271b1;
+  color: #fff;
+  border-color: #1a5d92;
+}
+
+.bokun-dashboard-no-results {
+  margin-top: 1rem;
+  font-style: italic;
+  color: #646970;
+  display: none;
+}
+
+.bokun-dashboard-no-results.is-visible {
+  display: block;
+}
+
+.bokun-dashboard-empty {
+  margin: 1rem 0;
+  font-style: italic;
+  color: #646970;
+}
+
+@media (max-width: 782px) {
+  .bokun-dashboard-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .bokun-dashboard-search {
+    width: 100%;
+  }
+
+  .bokun-dashboard-filter-toggle {
+    width: fit-content;
+  }
+
+  .bokun-dashboard-table {
+    min-width: 100%;
+  }
+}

--- a/assets/js/bokun-dashboard.js
+++ b/assets/js/bokun-dashboard.js
@@ -1,0 +1,242 @@
+(function ($) {
+  'use strict';
+
+  function getString(key, fallback) {
+    if (typeof window.bokunDashboard === 'object' && window.bokunDashboard !== null && Object.prototype.hasOwnProperty.call(window.bokunDashboard, key)) {
+      return window.bokunDashboard[key];
+    }
+
+    return fallback;
+  }
+
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise(function (resolve, reject) {
+      var $temp = $('<textarea readonly>');
+      $temp.css({
+        position: 'absolute',
+        left: '-9999px',
+        top: '0',
+      });
+      $('body').append($temp);
+      $temp.val(text).select();
+
+      try {
+        var successful = document.execCommand('copy');
+        if (successful) {
+          resolve();
+        } else {
+          reject();
+        }
+      } catch (error) {
+        reject(error);
+      }
+
+      $temp.remove();
+    });
+  }
+
+  function showCopyFeedback($button, isError) {
+    var originalText = $button.data('original-text');
+    if (!originalText) {
+      originalText = $.trim($button.text());
+      $button.data('original-text', originalText);
+    }
+
+    var message = getString(isError ? 'copyError' : 'copied', isError ? 'Error' : 'Copied!');
+
+    $button.addClass('has-feedback');
+    $button.text(message);
+
+    setTimeout(function () {
+      $button.removeClass('has-feedback');
+      $button.text(originalText);
+    }, 1500);
+  }
+
+  function normalise(value) {
+    return (value || '').toString().toLowerCase();
+  }
+
+  function applyFilters($dashboard) {
+    var $searchInput = $dashboard.find('.bokun-dashboard-search-input input');
+    var $filterCheckboxes = $dashboard.find('.bokun-dashboard-filter-options input[type="checkbox"]');
+    var $rows = $dashboard.find('tbody tr');
+    var $noResults = $dashboard.find('.bokun-dashboard-no-results');
+
+    var searchTerm = normalise($searchInput.val().trim());
+    var activeFilters = $filterCheckboxes.filter(':checked').map(function () {
+      return $(this).val();
+    }).get();
+    var hasFilter = activeFilters.length > 0;
+    var visibleCount = 0;
+
+    $rows.each(function () {
+      var $row = $(this);
+      var rowSearch = normalise($row.data('search'));
+      var rowStatuses = ($row.data('statuses') || '').toString().split('|').filter(Boolean);
+
+      var matchesSearch = !searchTerm || rowSearch.indexOf(searchTerm) !== -1;
+      var matchesFilter = !hasFilter || rowStatuses.some(function (status) {
+        return activeFilters.indexOf(status) !== -1;
+      });
+
+      var isVisible = matchesSearch && matchesFilter;
+      $row.toggle(isVisible);
+
+      if (isVisible) {
+        visibleCount += 1;
+      }
+    });
+
+    if ($noResults.length) {
+      var hasResults = visibleCount > 0;
+      if (!hasResults) {
+        var fallback = $noResults.data('default-text') || $noResults.text();
+        $noResults.text(getString('noResults', fallback));
+      } else {
+        var baseText = $noResults.data('default-text');
+        if (baseText) {
+          $noResults.text(baseText);
+        }
+      }
+
+      $noResults.toggleClass('is-visible', !hasResults);
+      $noResults.prop('hidden', hasResults);
+    }
+  }
+
+  function toggleClearButton($dashboard) {
+    var $searchInput = $dashboard.find('.bokun-dashboard-search-input input');
+    var $clearButton = $dashboard.find('.bokun-dashboard-clear-search');
+    if (!$clearButton.length) {
+      return;
+    }
+
+    var hasValue = Boolean($searchInput.val());
+    $clearButton.toggleClass('is-visible', hasValue);
+  }
+
+  function initDashboard($dashboard) {
+    var $searchInput = $dashboard.find('.bokun-dashboard-search-input input');
+    var $clearSearch = $dashboard.find('.bokun-dashboard-clear-search');
+    var $filterCheckboxes = $dashboard.find('.bokun-dashboard-filter-options input[type="checkbox"]');
+    var $filterToggle = $dashboard.find('.bokun-dashboard-filter-toggle');
+    var $filtersContainer = $dashboard.find('.bokun-dashboard-filters');
+    var $dropdown = $dashboard.find('.bokun-dashboard-filter-dropdown');
+    var $selectAllButton = $dashboard.find('.bokun-dashboard-filter-select-all');
+    var $clearFiltersButton = $dashboard.find('.bokun-dashboard-filter-clear');
+
+    function openDropdown() {
+      if (!$filtersContainer.length) {
+        return;
+      }
+
+      $('.bokun-dashboard-filters.is-open').not($filtersContainer).each(function () {
+        var $other = $(this);
+        $other.removeClass('is-open');
+        $other.find('.bokun-dashboard-filter-dropdown').prop('hidden', true);
+        $other.find('.bokun-dashboard-filter-toggle').attr('aria-expanded', 'false');
+      });
+
+      $filtersContainer.addClass('is-open');
+      $dropdown.prop('hidden', false);
+      $filterToggle.attr('aria-expanded', 'true');
+    }
+
+    function closeDropdown() {
+      if (!$filtersContainer.length) {
+        return;
+      }
+      $filtersContainer.removeClass('is-open');
+      $dropdown.prop('hidden', true);
+      $filterToggle.attr('aria-expanded', 'false');
+    }
+
+    $filterToggle.on('click', function () {
+      if ($filtersContainer.hasClass('is-open')) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    });
+
+    $filterCheckboxes.on('change', function () {
+      applyFilters($dashboard);
+    });
+
+    if ($selectAllButton.length) {
+      $selectAllButton.on('click', function () {
+        $filterCheckboxes.prop('checked', true);
+        applyFilters($dashboard);
+      });
+    }
+
+    if ($clearFiltersButton.length) {
+      $clearFiltersButton.on('click', function () {
+        $filterCheckboxes.prop('checked', false);
+        applyFilters($dashboard);
+      });
+    }
+
+    $searchInput.on('input', function () {
+      toggleClearButton($dashboard);
+      applyFilters($dashboard);
+    });
+
+    $clearSearch.on('click', function () {
+      $searchInput.val('');
+      toggleClearButton($dashboard);
+      applyFilters($dashboard);
+      $searchInput.trigger('focus');
+    });
+
+    $dashboard.on('click', '.bokun-dashboard-copy-button', function () {
+      var $button = $(this);
+      var value = $button.data('copyValue');
+      if (typeof value === 'undefined') {
+        return;
+      }
+
+      copyToClipboard(value.toString()).then(function () {
+        showCopyFeedback($button, false);
+      }).catch(function () {
+        showCopyFeedback($button, true);
+      });
+    });
+
+    toggleClearButton($dashboard);
+    applyFilters($dashboard);
+  }
+
+  function handleDocumentClick(event) {
+    var $target = $(event.target);
+
+    $('.bokun-dashboard-filters.is-open').each(function () {
+      var $filters = $(this);
+      if ($filters.is($target) || $filters.has($target).length) {
+        return;
+      }
+
+      $filters.removeClass('is-open');
+      $filters.find('.bokun-dashboard-filter-dropdown').prop('hidden', true);
+      $filters.find('.bokun-dashboard-filter-toggle').attr('aria-expanded', 'false');
+    });
+  }
+
+  $(function () {
+    var $dashboards = $('.bokun-dashboard');
+    if (!$dashboards.length) {
+      return;
+    }
+
+    $(document).on('click.bokunDashboard', handleDocumentClick);
+
+    $dashboards.each(function () {
+      initDashboard($(this));
+    });
+  });
+})(jQuery);

--- a/bokun-bookings-management.php
+++ b/bokun-bookings-management.php
@@ -293,11 +293,18 @@ class BokunBookingManagement {
         // need to check here if its front section than enqueue script
         /*********** register and enqueue styles ***************/
 
-            wp_register_style( 
-                'bokun_front_css',  
-                BOKUN_CSS_URL.'bokun_front.css?rand='.rand(1,999), 
-                false, 
-                $bokun_version 
+            wp_register_style(
+                'bokun_front_css',
+                BOKUN_CSS_URL.'bokun_front.css?rand='.rand(1,999),
+                false,
+                $bokun_version
+            );
+
+            wp_register_style(
+                'bokun_dashboard_css',
+                BOKUN_CSS_URL.'bokun_dashboard.css?rand='.rand(1,999),
+                [],
+                $bokun_version
             );
 
             // wp_enqueue_style( 'bokun_front_css' );
@@ -306,12 +313,20 @@ class BokunBookingManagement {
             /*********** register and enqueue scripts ***************/
             echo "<script> var ajaxurl = '".admin_url( 'admin-ajax.php' )."'; </script>";
 
-            wp_register_script( 
-                'bokun_front_js', 
-                BOKUN_JS_URL.'bokun_front.js?rand='.rand(1,999), 
-                'jQuery', 
-                $bokun_version, 
-                true 
+            wp_register_script(
+                'bokun_front_js',
+                BOKUN_JS_URL.'bokun_front.js?rand='.rand(1,999),
+                'jQuery',
+                $bokun_version,
+                true
+            );
+
+            wp_register_script(
+                'bokun_dashboard_js',
+                BOKUN_JS_URL.'bokun-dashboard.js?rand='.rand(1,999),
+                ['jquery'],
+                $bokun_version,
+                true
             );
 
             wp_enqueue_script( 'bokun_front_js' );           

--- a/includes/bokun-bookings-manager.php
+++ b/includes/bokun-bookings-manager.php
@@ -973,6 +973,226 @@ function retrieve_partnerpageid_shortcode($atts) {
 }
 add_shortcode('partnerpageid', 'retrieve_partnerpageid_shortcode');
 
+function bokun_dashboard_shortcode($atts = []) {
+    $atts = shortcode_atts(
+        [
+            'status_taxonomy' => 'booking_status',
+            'posts_per_page'  => -1,
+        ],
+        $atts,
+        'bokun_dashboard'
+    );
+
+    // Ensure assets are available when the shortcode renders.
+    if (!wp_style_is('bokun_dashboard_css', 'registered')) {
+        wp_register_style(
+            'bokun_dashboard_css',
+            BOKUN_CSS_URL . 'bokun_dashboard.css',
+            [],
+            null
+        );
+    }
+
+    if (!wp_script_is('bokun_dashboard_js', 'registered')) {
+        wp_register_script(
+            'bokun_dashboard_js',
+            BOKUN_JS_URL . 'bokun-dashboard.js',
+            ['jquery'],
+            null,
+            true
+        );
+    }
+
+    wp_enqueue_style('bokun_dashboard_css');
+    wp_enqueue_script('bokun_dashboard_js');
+
+    static $dashboard_i18n_enqueued = false;
+    if (!$dashboard_i18n_enqueued) {
+        wp_localize_script(
+            'bokun_dashboard_js',
+            'bokunDashboard',
+            [
+                'copied'    => esc_html__('Copied!', BOKUN_txt_domain),
+                'copyError' => esc_html__('Unable to copy value.', BOKUN_txt_domain),
+                'noResults' => esc_html__('No bookings match your filters.', BOKUN_txt_domain),
+            ]
+        );
+        $dashboard_i18n_enqueued = true;
+    }
+
+    $status_taxonomy = sanitize_key($atts['status_taxonomy']);
+    $statuses        = [];
+
+    if (!empty($status_taxonomy) && taxonomy_exists($status_taxonomy)) {
+        $statuses = get_terms([
+            'taxonomy'   => $status_taxonomy,
+            'hide_empty' => false,
+            'orderby'    => 'name',
+            'order'      => 'ASC',
+        ]);
+        if (is_wp_error($statuses)) {
+            $statuses = [];
+        }
+    }
+
+    $posts_per_page = intval($atts['posts_per_page']);
+    if ($posts_per_page === 0) {
+        $posts_per_page = -1;
+    }
+
+    $query = new WP_Query([
+        'post_type'      => 'bokun_booking',
+        'post_status'    => 'publish',
+        'posts_per_page' => $posts_per_page,
+        'no_found_rows'  => true,
+        'orderby'        => 'meta_value',
+        'meta_key'       => '_original_start_date',
+        'order'          => 'ASC',
+    ]);
+
+    if (!$query->have_posts()) {
+        wp_reset_postdata();
+
+        return '<p class="bokun-dashboard-empty">' . esc_html__('No bookings available right now.', BOKUN_txt_domain) . '</p>';
+    }
+
+    $search_input_id = wp_unique_id('bokun-dashboard-search-');
+    $dropdown_id     = wp_unique_id('bokun-dashboard-filters-');
+
+    ob_start();
+    ?>
+    <div class="bokun-dashboard" data-filter-taxonomy="<?php echo esc_attr($status_taxonomy); ?>">
+        <div class="bokun-dashboard-controls">
+            <div class="bokun-dashboard-search">
+                <label class="screen-reader-text" for="<?php echo esc_attr($search_input_id); ?>"><?php esc_html_e('Search bookings', BOKUN_txt_domain); ?></label>
+                <div class="bokun-dashboard-search-input">
+                    <input type="search" id="<?php echo esc_attr($search_input_id); ?>" placeholder="<?php echo esc_attr__('Search bookings…', BOKUN_txt_domain); ?>" autocomplete="off">
+                    <button type="button" class="bokun-dashboard-clear-search" aria-label="<?php echo esc_attr__('Clear search', BOKUN_txt_domain); ?>">&times;</button>
+                </div>
+            </div>
+            <?php if (!empty($statuses)) : ?>
+                <div class="bokun-dashboard-filters" data-dropdown-id="<?php echo esc_attr($dropdown_id); ?>">
+                    <button type="button" class="bokun-dashboard-filter-toggle" aria-expanded="false" aria-controls="<?php echo esc_attr($dropdown_id); ?>"><?php esc_html_e('Filters', BOKUN_txt_domain); ?></button>
+                    <div id="<?php echo esc_attr($dropdown_id); ?>" class="bokun-dashboard-filter-dropdown" hidden>
+                        <div class="bokun-dashboard-filter-actions">
+                            <button type="button" class="bokun-dashboard-filter-select-all"><?php esc_html_e('Select All', BOKUN_txt_domain); ?></button>
+                            <button type="button" class="bokun-dashboard-filter-clear"><?php esc_html_e('Clear All', BOKUN_txt_domain); ?></button>
+                        </div>
+                        <ul class="bokun-dashboard-filter-options">
+                            <?php foreach ($statuses as $status) :
+                                $slug        = sanitize_title($status->name);
+                                $checkbox_id = wp_unique_id('bokun-dashboard-filter-option-');
+                                ?>
+                                <li>
+                                    <label for="<?php echo esc_attr($checkbox_id); ?>">
+                                        <input type="checkbox" id="<?php echo esc_attr($checkbox_id); ?>" value="<?php echo esc_attr($slug); ?>" checked>
+                                        <span><?php echo esc_html($status->name); ?></span>
+                                    </label>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                </div>
+            <?php endif; ?>
+        </div>
+        <div class="bokun-dashboard-table-wrapper">
+            <table class="bokun-dashboard-table">
+                <thead>
+                    <tr>
+                        <th scope="col"><?php esc_html_e('Booking', BOKUN_txt_domain); ?></th>
+                        <th scope="col"><?php esc_html_e('First Name', BOKUN_txt_domain); ?></th>
+                        <th scope="col"><?php esc_html_e('Last Name', BOKUN_txt_domain); ?></th>
+                        <th scope="col"><?php esc_html_e('Phone Number', BOKUN_txt_domain); ?></th>
+                        <th scope="col"><?php esc_html_e('Reference Number', BOKUN_txt_domain); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php
+                    while ($query->have_posts()) {
+                        $query->the_post();
+                        $post_id       = get_the_ID();
+                        $title         = get_the_title();
+                        $permalink     = get_permalink();
+                        $first_name    = trim((string) get_post_meta($post_id, '_first_name', true));
+                        $last_name     = trim((string) get_post_meta($post_id, '_last_name', true));
+                        $phone_prefix  = trim((string) get_post_meta($post_id, '_phone_prefix', true));
+                        $phone_number  = trim((string) get_post_meta($post_id, '_phone_number', true));
+                        $reference     = trim((string) get_post_meta($post_id, '_external_booking_reference', true));
+                        $phone_display = trim($phone_prefix . ' ' . $phone_number);
+
+                        $row_terms      = [];
+                        $row_term_slugs = [];
+
+                        if (!empty($status_taxonomy) && taxonomy_exists($status_taxonomy)) {
+                            $row_terms = wp_get_post_terms($post_id, $status_taxonomy);
+                            if (!is_wp_error($row_terms)) {
+                                $row_term_slugs = array_map(static function ($term) {
+                                    return sanitize_title($term->name);
+                                }, $row_terms);
+                            } else {
+                                $row_terms = [];
+                            }
+                        }
+
+                        $search_parts = array_filter([
+                            $title,
+                            $first_name,
+                            $last_name,
+                            $phone_display,
+                            $reference,
+                        ], static function ($value) {
+                            return '' !== trim((string) $value);
+                        });
+
+                        $search_text = wp_strip_all_tags(implode(' ', $search_parts));
+                        $search_text = function_exists('mb_strtolower') ? mb_strtolower($search_text) : strtolower($search_text);
+
+                        ?>
+                        <tr data-statuses="<?php echo esc_attr(implode('|', $row_term_slugs)); ?>" data-search="<?php echo esc_attr($search_text); ?>">
+                            <td data-title="<?php esc_attr_e('Booking', BOKUN_txt_domain); ?>">
+                                <a href="<?php echo esc_url($permalink); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($title); ?></a>
+                                <button type="button" class="bokun-dashboard-copy-button" data-copy-value="<?php echo esc_attr($permalink); ?>" aria-label="<?php echo esc_attr(sprintf(__('Copy link for %s', BOKUN_txt_domain), $title)); ?>"><?php esc_html_e('Copy', BOKUN_txt_domain); ?></button>
+                            </td>
+                            <td data-title="<?php esc_attr_e('First Name', BOKUN_txt_domain); ?>">
+                                <span><?php echo $first_name !== '' ? esc_html($first_name) : '&mdash;'; ?></span>
+                                <?php if ($first_name !== '') : ?>
+                                    <button type="button" class="bokun-dashboard-copy-button" data-copy-value="<?php echo esc_attr($first_name); ?>" aria-label="<?php echo esc_attr(sprintf(__('Copy first name %s', BOKUN_txt_domain), $first_name)); ?>"><?php esc_html_e('Copy', BOKUN_txt_domain); ?></button>
+                                <?php endif; ?>
+                            </td>
+                            <td data-title="<?php esc_attr_e('Last Name', BOKUN_txt_domain); ?>">
+                                <span><?php echo $last_name !== '' ? esc_html($last_name) : '&mdash;'; ?></span>
+                                <?php if ($last_name !== '') : ?>
+                                    <button type="button" class="bokun-dashboard-copy-button" data-copy-value="<?php echo esc_attr($last_name); ?>" aria-label="<?php echo esc_attr(sprintf(__('Copy last name %s', BOKUN_txt_domain), $last_name)); ?>"><?php esc_html_e('Copy', BOKUN_txt_domain); ?></button>
+                                <?php endif; ?>
+                            </td>
+                            <td data-title="<?php esc_attr_e('Phone Number', BOKUN_txt_domain); ?>">
+                                <span><?php echo $phone_display !== '' ? esc_html($phone_display) : '&mdash;'; ?></span>
+                                <?php if ($phone_display !== '') : ?>
+                                    <button type="button" class="bokun-dashboard-copy-button" data-copy-value="<?php echo esc_attr($phone_display); ?>" aria-label="<?php echo esc_attr(sprintf(__('Copy phone number %s', BOKUN_txt_domain), $phone_display)); ?>"><?php esc_html_e('Copy', BOKUN_txt_domain); ?></button>
+                                <?php endif; ?>
+                            </td>
+                            <td data-title="<?php esc_attr_e('Reference Number', BOKUN_txt_domain); ?>">
+                                <span><?php echo $reference !== '' ? esc_html($reference) : '&mdash;'; ?></span>
+                                <?php if ($reference !== '') : ?>
+                                    <button type="button" class="bokun-dashboard-copy-button" data-copy-value="<?php echo esc_attr($reference); ?>" aria-label="<?php echo esc_attr(sprintf(__('Copy reference number %s', BOKUN_txt_domain), $reference)); ?>"><?php esc_html_e('Copy', BOKUN_txt_domain); ?></button>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <?php
+                    }
+                    ?>
+                </tbody>
+            </table>
+        </div>
+        <p class="bokun-dashboard-no-results" role="status" aria-live="polite" hidden data-default-text="<?php echo esc_attr__('No bookings match your filters.', BOKUN_txt_domain); ?>"><?php echo esc_html__('No bookings match your filters.', BOKUN_txt_domain); ?></p>
+    </div>
+    <?php
+    wp_reset_postdata();
+
+    return ob_get_clean();
+}
+add_shortcode('bokun_dashboard', 'bokun_dashboard_shortcode');
+
 // Helper function to extract inclusions after the third '---'
 function bokun_get_inclusions_clean($text) {
     // Standardize the separators


### PR DESCRIPTION
## Summary
- add a front-end dashboard shortcode that lists bookings with copy-to-clipboard buttons and search/filter controls
- register the new dashboard assets and ship dedicated styling for the dropdown filters and copy helpers
- implement JavaScript to drive copy feedback, dropdown toggling, clearable search, and multi-select filtering

## Testing
- php -l bokun-bookings-management.php
- php -l includes/bokun-bookings-manager.php

------
https://chatgpt.com/codex/tasks/task_e_6907b26657548320b7fbce815d9ca28d